### PR TITLE
Fixed glob matching work through Path.parse

### DIFF
--- a/lib/lutaml/path/parser.rb
+++ b/lib/lutaml/path/parser.rb
@@ -12,16 +12,14 @@ module Lutaml
       rule(:separator) { str("::") }
 
       # Character rules
-      rule(:glob_char) { match('[*?\[{]') }
       rule(:regular_char) do
         (separator.absent? >> str("\\").absent? >> any) |
           escaped_separator
       end
 
-      # Single segment can contain any regular chars or glob chars
+      # Single segment can contain any regular chars
       rule(:segment_content) do
-        (glob_char | regular_char).repeat(1).as(:content) >>
-          glob_char.present?.maybe.as(:is_pattern)
+        regular_char.repeat(1).as(:content)
       end
 
       rule(:segment) do
@@ -34,8 +32,8 @@ module Lutaml
 
       # Full path expression - either absolute or relative
       rule(:path_expr) do
-        ((separator.as(:absolute) >> segment.as(:first_segment) >> segments) |
-         (segment.as(:first_segment) >> segments))
+        (separator.as(:absolute) >> segment.as(:first_segment) >> segments) |
+          (segment.as(:first_segment) >> segments)
       end
 
       root(:path_expr)

--- a/lib/lutaml/path/path_segment.rb
+++ b/lib/lutaml/path/path_segment.rb
@@ -3,11 +3,13 @@
 module Lutaml
   module Path
     class PathSegment
-      attr_reader :name, :pattern
+      GLOB_CHARS = /[*?\[{]/
 
-      def initialize(name, is_pattern: false)
+      attr_reader :name
+
+      def initialize(name)
         @name = name.gsub('\::', "::")
-        @pattern = is_pattern
+        @pattern = @name.match?(GLOB_CHARS)
       end
 
       def pattern?
@@ -15,7 +17,7 @@ module Lutaml
       end
 
       def match?(segment)
-        return File.fnmatch(name, segment) if pattern?
+        return File.fnmatch(name, segment, File::FNM_EXTGLOB) if pattern?
 
         name == segment
       end

--- a/lib/lutaml/path/transformer.rb
+++ b/lib/lutaml/path/transformer.rb
@@ -6,10 +6,8 @@ require "parslet"
 module Lutaml
   module Path
     class Transformer < Parslet::Transform
-      rule(content: simple(:content), is_pattern: simple(:is_pattern)) do |dict|
-        content = dict[:content].to_s
-        is_pattern = !dict[:is_pattern].nil?
-        PathSegment.new(content, is_pattern: is_pattern)
+      rule(content: simple(:content)) do |dict|
+        PathSegment.new(dict[:content].to_s)
       end
 
       rule(segment: subtree(:segment)) { segment }

--- a/spec/lutaml/path_spec.rb
+++ b/spec/lutaml/path_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Lutaml::Path do
       expect(path.segments.map(&:name)).to eq(%w[Package Element])
     end
 
-    xit "parses paths with patterns" do
+    it "parses paths with patterns" do
       path = described_class.parse("Package::*::Base*")
       expect(path.segments.map(&:pattern?)).to eq([false, true, true])
       expect(path.segments.map(&:name)).to eq(["Package", "*", "Base*"])
@@ -29,15 +29,33 @@ RSpec.describe Lutaml::Path do
       expect(path.segments.map(&:name)).to eq(["core::types", "Element"])
     end
 
+    it "does not treat escaped separators as patterns" do
+      path = described_class.parse("core\\::types::Element")
+      expect(path.segments.map(&:pattern?)).to eq([false, false])
+    end
+
     it "handles Unicode characters" do
       path = described_class.parse("建物::窓::ガラス")
       expect(path.segments.map(&:name)).to eq(%w[建物 窓 ガラス])
     end
 
-    xit "handles glob patterns" do
+    it "handles glob patterns" do
       path = described_class.parse("pkg::{a,b}*::[0-9]*")
       expect(path.segments.last.pattern?).to be true
       expect(path.match?(%w[pkg btest 123])).to be true
+    end
+
+    it "matches a single-segment wildcard end to end" do
+      path = described_class.parse("Package::*::BaseClass")
+      expect(path.match?(%w[Package core BaseClass])).to be true
+      expect(path.match?(%w[Package BaseClass])).to be false
+    end
+
+    it "matches brace alternation end to end" do
+      path = described_class.parse("model::{Abstract,Base}Class")
+      expect(path.match?(%w[model AbstractClass])).to be true
+      expect(path.match?(%w[model BaseClass])).to be true
+      expect(path.match?(%w[model OtherClass])).to be false
     end
 
     it "raises error on empty segments" do
@@ -48,41 +66,61 @@ RSpec.describe Lutaml::Path do
       expect { described_class.parse("") }.to raise_error(described_class::ParseError)
     end
   end
+end
 
-  describe Lutaml::Path::PathSegment do
-    it "matches exact names" do
-      segment = described_class.new("Element")
-      expect(segment.match?("Element")).to be true
-      expect(segment.match?("Other")).to be false
-    end
-
-    it "matches patterns" do
-      segment = described_class.new("Base*", is_pattern: true)
-      expect(segment.match?("BaseClass")).to be true
-      expect(segment.match?("Other")).to be false
-    end
+RSpec.describe Lutaml::Path::PathSegment do
+  it "matches exact names" do
+    segment = described_class.new("Element")
+    expect(segment.match?("Element")).to be true
+    expect(segment.match?("Other")).to be false
   end
 
-  describe Lutaml::Path::ElementPath do
-    it "matches path segments" do
-      path = described_class.new([
-                                   Lutaml::Path::PathSegment.new("pkg"),
-                                   Lutaml::Path::PathSegment.new("*", is_pattern: true),
-                                   Lutaml::Path::PathSegment.new("Element")
-                                 ])
+  it "matches patterns" do
+    segment = described_class.new("Base*")
+    expect(segment.match?("BaseClass")).to be true
+    expect(segment.match?("Other")).to be false
+  end
 
-      expect(path.match?(%w[pkg sub Element])).to be true
-      expect(path.match?(%w[other sub Element])).to be false
-    end
+  it "derives pattern-ness from the name" do
+    expect(described_class.new("Base*").pattern?).to be true
+    expect(described_class.new("Element").pattern?).to be false
+  end
 
-    it "respects absolute paths" do
-      path = described_class.new([
-                                   Lutaml::Path::PathSegment.new("pkg"),
-                                   Lutaml::Path::PathSegment.new("Element")
-                                 ], absolute: true)
+  it "matches brace alternation" do
+    segment = described_class.new("{Base,Case}")
+    expect(segment.match?("Base")).to be true
+    expect(segment.match?("Case")).to be true
+    expect(segment.match?("Vase")).to be false
+  end
 
-      expect(path.match?(%w[pkg Element])).to be true
-      expect(path.match?(%w[root pkg Element])).to be false
-    end
+  it "matches character sets, ranges, and negation" do
+    expect(described_class.new("[abc]x").match?("bx")).to be true
+    expect(described_class.new("[abc]x").match?("dx")).to be false
+    expect(described_class.new("[a-z]*").match?("query")).to be true
+    expect(described_class.new("[!CV]ase").match?("Base")).to be true
+    expect(described_class.new("[!CV]ase").match?("Case")).to be false
+  end
+end
+
+RSpec.describe Lutaml::Path::ElementPath do
+  it "matches path segments" do
+    path = described_class.new([
+                                 Lutaml::Path::PathSegment.new("pkg"),
+                                 Lutaml::Path::PathSegment.new("*"),
+                                 Lutaml::Path::PathSegment.new("Element")
+                               ])
+
+    expect(path.match?(%w[pkg sub Element])).to be true
+    expect(path.match?(%w[other sub Element])).to be false
+  end
+
+  it "respects absolute paths" do
+    path = described_class.new([
+                                 Lutaml::Path::PathSegment.new("pkg"),
+                                 Lutaml::Path::PathSegment.new("Element")
+                               ], absolute: true)
+
+    expect(path.match?(%w[pkg Element])).to be true
+    expect(path.match?(%w[root pkg Element])).to be false
   end
 end


### PR DESCRIPTION
## Summary

Glob matching via `Lutaml::Path.parse` never worked. Two defects, fixed together:

- The parser's `glob_char.present?` lookahead never fired, so `is_pattern` was always `nil` and every segment matched by plain string equality.
- `File.fnmatch` was missing `FNM_EXTGLOB`, so brace alternation `{a,b}` matched literally.

## Approach

- Pattern-ness is now derived from the segment name instead of being passed in. The flag disagreeing with the name is what caused the bug, so now it can't happen.
- The grammar no longer knows about globs. `glob_char` was already redundant with `regular_char`, so it's deleted.
- Glob handling now lives in one place, the class that calls `fnmatch`.

## Breaking change

- `PathSegment.new` no longer takes `is_pattern:`. Just pass the name. Passing it raises `ArgumentError`.
- This only hits callers who built segments by hand to work around the bug. The README only documents `Lutaml::Path.parse`. Gem is `0.1.0`.
- `attr_reader :pattern` is removed since `pattern?` already does the job.

## Testing

- Un-pends both `xit`s: `parses paths with patterns` and `handles glob patterns`.
- Adds coverage for brace alternation, single-segment wildcard, `[abc]`/`[a-z]`/`[!CV]`, and escaped separators.
- `bundle exec rake`: 18 examples, 0 failures, no offenses.

## Notes

- Malformed openers like `Pkg::Foo[` no longer match themselves since `fnmatch` rejects the unterminated bracket. Nothing in the README uses these.
- Includes an unrelated RuboCop autocorrect in `path_expr`. `rake` was already red on `main` because of it, now it's green.