### PR TITLE
fix: reject leading escaped separator per spec

### DIFF
--- a/lib/lutaml/path/parser.rb
+++ b/lib/lutaml/path/parser.rb
@@ -36,7 +36,15 @@ module Lutaml
           (segment.as(:first_segment) >> segments)
       end
 
-      root(:path_expr)
+      # The leading separator cannot be escaped (README: "the leading hierarchy
+      # separator ... cannot be escaped"). Guard position 0 of the input; a real
+      # leading `::` is fine, so absolute paths and later-segment escapes are
+      # unaffected.
+      rule(:path) do
+        escaped_separator.absent? >> path_expr
+      end
+
+      root(:path)
     end
   end
 end

--- a/spec/lutaml/path_spec.rb
+++ b/spec/lutaml/path_spec.rb
@@ -34,6 +34,22 @@ RSpec.describe Lutaml::Path do
       expect(path.segments.map(&:pattern?)).to eq([false, false])
     end
 
+    it "rejects a leading escaped separator" do
+      expect { described_class.parse("\\::Rectangle") }.to raise_error(described_class::ParseError)
+      expect { described_class.parse("\\::Rectangle::Shape") }.to raise_error(described_class::ParseError)
+    end
+
+    it "allows an escaped separator in a later segment" do
+      path = described_class.parse("model::\\::odd")
+      expect(path.segments.map(&:name)).to eq(["model", "::odd"])
+    end
+
+    it "allows an escaped separator after a real leading separator" do
+      path = described_class.parse("::\\::odd")
+      expect(path.absolute?).to be true
+      expect(path.segments.map(&:name)).to eq(["::odd"])
+    end
+
     it "handles Unicode characters" do
       path = described_class.parse("建物::窓::ガラス")
       expect(path.segments.map(&:name)).to eq(%w[建物 窓 ガラス])


### PR DESCRIPTION
## Summary

`README.adoc` says the leading hierarchy separator cannot be escaped, so `\::Rectangle` is invalid. The parser accepted it, parsing it as a relative path with one segment named `::Rectangle`. Now it raises `ParseError`.

## Change

- Add a root guard `rule(:path) { escaped_separator.absent? >> path_expr }` and point `root` at it.
- `path_expr` is untouched. The guard is zero-width, so no existing parse tree changes and the transformer is unaffected.

## Behavior

- `\::Rectangle` and `\::Rectangle::Shape` now raise `ParseError`.
- `::\::odd` stays valid, since its leading separator is real and only a later one is escaped.
- Mid-path escapes like `core\::types` are unchanged.

## Testing

- Three examples: rejects a leading escaped separator, allows one in a later segment, allows one after a real leading separator.
- `bundle exec rake`: 21 examples, 0 failures, no offenses.